### PR TITLE
Fix post-process phase logic and update material settings

### DIFF
--- a/Assets/Resources_Temp/DunGen/Samples/Dungeon Crawler Sample/Environment/Castle/Meshes/Materials/CastleEnvironment.mat
+++ b/Assets/Resources_Temp/DunGen/Samples/Dungeon Crawler Sample/Environment/Castle/Meshes/Materials/CastleEnvironment.mat
@@ -15,7 +15,7 @@ Material:
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
+  m_DoubleSidedGI: 1
   m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Opaque
@@ -91,7 +91,7 @@ Material:
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
-    - _Cull: 2
+    - _Cull: 0
     - _Cutoff: 0.5
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1

--- a/Assets/Resources_Temp/Invironment_Temp/DunGen/Code/DungeonGenerator.cs
+++ b/Assets/Resources_Temp/Invironment_Temp/DunGen/Code/DungeonGenerator.cs
@@ -1025,14 +1025,14 @@ namespace DunGen
 			});
 
 			// Apply any post-process to be run BEFORE built-in post-processing is run
-			foreach (var step in postProcessSteps)
-			{
-				if (ShouldSkipFrame(false))
-					yield return null;
+			foreach (var step in postProcessSteps.ToList()) // <--- THÊM .ToList()
+{
+    if (ShouldSkipFrame(false))
+        yield return null;
 
-				if (step.Phase == PostProcessPhase.BeforeBuiltIn)
-					step.PostProcessCallback(this);
-			}
+    if (step.Phase == PostProcessPhase.AfterBuiltIn)
+        step.PostProcessCallback(this);
+}
 
 
 			// Waiting one frame so objects are in their expected state
@@ -1064,14 +1064,14 @@ namespace DunGen
 
 
 			// Apply any post-process to be run AFTER built-in post-processing is run
-			foreach (var step in postProcessSteps)
-			{
-				if (ShouldSkipFrame(false))
-					yield return null;
+			foreach (var step in postProcessSteps.ToList()) // <--- THÊM .ToList()
+{
+    if (ShouldSkipFrame(false))
+        yield return null;
 
-				if (step.Phase == PostProcessPhase.AfterBuiltIn)
-					step.PostProcessCallback(this);
-			}
+    if (step.Phase == PostProcessPhase.BeforeBuiltIn)
+        step.PostProcessCallback(this);
+}
 
 
 			// Finalise


### PR DESCRIPTION
Corrected the phase checks in DungeonGenerator.cs to ensure post-process steps are executed in the intended order and converted enumerations to lists for safe iteration. Updated CastleEnvironment.mat to enable double-sided GI and set culling to 'Off' for improved rendering.